### PR TITLE
Change prefix to avoid conflict with the existing jnt:release

### DIFF
--- a/src/javascript/ContentReleaseManager/ContentReleaseManagerCmp.jsx
+++ b/src/javascript/ContentReleaseManager/ContentReleaseManagerCmp.jsx
@@ -22,7 +22,7 @@ const styles = () => ({
         backgroundColor: 'var(--color-gray_light)'
     }
 });
-const contentType = 'jnt:release';
+const contentType = 'releasent:release';
 const ContentReleaseManagerCmp = props => {
     const {classes} = props;
     const {state, dispatch} = React.useContext(StoreContext);

--- a/src/main/import/repository.xml
+++ b/src/main/import/repository.xml
@@ -13,7 +13,7 @@
             <files jcr:primaryType="jnt:folder"/>
             <contents jcr:primaryType="jnt:contentFolder"/>
          </templates>
-         <releases-manager jcr:primaryType="jnt:releaseFolder">
+         <releases-manager jcr:primaryType="releasent:releaseFolder">
             <help jcr:primaryType="jnt:bigText">
                <j:translation_en jcr:language="en"
                                  jcr:primaryType="jnt:translation"
@@ -37,7 +37,7 @@
                                     jcr:primaryType="jnt:translation"
                                     text="&lt;h1&gt;How to use content release?&lt;/h1&gt;&#xA;&#xA;&lt;h2&gt;Create a new release&lt;/h2&gt;&#xA;&#xA;&lt;p&gt;The release are available per site, and can also be created/removed when editing the site node with Content Editor.&lt;br /&gt;&#xA;The user needs to have the write permission on the site node in order to create a new release.&lt;/p&gt;&#xA;&#xA;&lt;h2&gt;Assign a page or a content item to a release&lt;/h2&gt;&#xA;&#xA;&lt;ol&gt;&#xA; &lt;li&gt;Simply open Content Editor for the page content&lt;/li&gt;&#xA; &lt;li&gt;Scroll to the &amp;quot;Options&amp;quot; section&lt;/li&gt;&#xA; &lt;li&gt;Enable the &amp;quot;Content release&amp;quot; option&lt;/li&gt;&#xA; &lt;li&gt;Select the previously created release&lt;/li&gt;&#xA; &lt;li&gt;Click Save&lt;/li&gt;&#xA;&lt;/ol&gt;&#xA;&#xA;&lt;h2&gt;See the related contents&lt;/h2&gt;&#xA;&#xA;&lt;p&gt;It opens in a new tab the list of contents marked for the release, you can then easily access all the contents for your release.&lt;br /&gt;&#xA;Use the preview (right click -&amp;gt; &amp;quot;Preview&amp;quot;) to preview the contents in jContent.&lt;br /&gt;&#xA;Don&amp;#39;t hesitate to use the &amp;quot;Open in Page Composer&amp;quot; option in the context menu of each entry to open the content in Page Composer.&lt;/p&gt;&#xA;&#xA;&lt;p&gt;From jContent, you can select all your content and publish them all at once or schedule their publication if you are using the Scheduled Publication Workflow.&lt;/p&gt;&#xA;&#xA;&lt;p&gt;Please note that if &amp;quot;edit permissions&amp;quot; are not consistent accross all the content, then several workflows will be started.&lt;/p&gt;&#xA;&#xA;&lt;p&gt;&amp;nbsp;&lt;/p&gt;&#xA;"/>
             </help>
-            <releases jcr:primaryType="jnt:releaseFolder"/>
+            <releases jcr:primaryType="releasent:releaseFolder"/>
          </releases-manager>
       </content-releases>
    </modules>

--- a/src/main/resources/META-INF/definitions.cnd
+++ b/src/main/resources/META-INF/definitions.cnd
@@ -1,16 +1,18 @@
 <jmix = 'http://www.jahia.org/jahia/mix/1.0'>
+<releasemix = 'http://www.jahia.org/release/mix/1.0'>
 <jnt = 'http://www.jahia.org/jahia/nt/1.0'>
+<releasent = 'http://www.jahia.org/release/nt/1.0'>
 
-[jmix:releaseItem] mixin
+[releasemix:releaseItem] mixin
  extends = jnt:content, jnt:page
  itemtype = options
- - releases (weakreference, choicelist[nodes='$currentSite/releases-manager/releases;jnt:release']) multiple < 'jnt:release'
+ - releases (weakreference, choicelist[nodes='$currentSite/releases-manager/releases;releasent:release']) multiple < 'releasent:release'
 
-[jnt:releaseFolder] > nt:base, jmix:nolive
- + * (jnt:release)
- + * (jnt:releaseFolder)
+[releasent:releaseFolder] > nt:base, jmix:nolive
+ + * (releasent:release)
+ + * (releasent:releaseFolder)
  + * (jnt:bigText)
 
-[jnt:release] > nt:base, jmix:nolive, mix:created, mix:lastModified
+[releasent:release] > nt:base, jmix:nolive, mix:created, mix:lastModified
  - name (string) mandatory primary
 

--- a/src/main/resources/resources/content-releases.properties
+++ b/src/main/resources/resources/content-releases.properties
@@ -1,4 +1,4 @@
-jmix_releaseItem=Release Manager
-jmix_releaseItem.releases=Releases
-jnt_release.jcr_title=Release Name
+releasemix_releaseItem=Release Manager
+releasemix_releaseItem.releases=Releases
+releasent_release.jcr_title=Release Name
 label.permission.contentReleaseManager.description=Allow user to create and manage content release

--- a/src/main/resources/resources/content-releases_de.properties
+++ b/src/main/resources/resources/content-releases_de.properties
@@ -1,4 +1,4 @@
 #/src/main/resources/resources/content-releases_de.properties
 #Wed Aug 25 12:29:39 CEST 2021
-jnt_release.name=name
-jnt_release=release
+releasent_release.name=name
+releasent_release=release

--- a/src/main/resources/resources/content-releases_de_DE.properties
+++ b/src/main/resources/resources/content-releases_de_DE.properties
@@ -1,3 +1,3 @@
 #/src/main/resources/resources/content-releases_de_DE.properties
 #Wed Aug 25 12:29:39 CEST 2021
-jnt_release=release
+releasent_release=release

--- a/src/main/resources/resources/content-releases_en.properties
+++ b/src/main/resources/resources/content-releases_en.properties
@@ -1,4 +1,4 @@
 #/src/main/resources/resources/content-releases_en.properties
 #Wed Aug 25 12:29:39 CEST 2021
-jnt_release.name=name
-jnt_release=release
+releasent_release.name=name
+releasent_release=release

--- a/src/main/resources/resources/content-releases_es.properties
+++ b/src/main/resources/resources/content-releases_es.properties
@@ -1,4 +1,4 @@
 #/src/main/resources/resources/content-releases_es.properties
 #Wed Aug 25 12:29:39 CEST 2021
-jnt_release.name=name
-jnt_release=release
+releasent_release.name=name
+releasent_release=release

--- a/src/main/resources/resources/content-releases_fr.properties
+++ b/src/main/resources/resources/content-releases_fr.properties
@@ -1,9 +1,9 @@
 #/src/main/resources/resources/content-releases_fr.properties
 #Wed Aug 25 12:29:39 CEST 2021
-jnt_release=release
-jnt_release.name=Nom de la livraisons
-jmix_releaseItem=Gestionnaire de livraisons
-jmix_releaseItem.releases=Livraisons
+releasent_release=release
+releasent_release.name=Nom de la livraisons
+releasemix_releaseItem=Gestionnaire de livraisons
+releasemix_releaseItem.releases=Livraisons
 label.permission.contentReleaseManager.description=Authorise un utilisateur à utiliser le gestionnaire de livraisons 
 
 

--- a/src/main/resources/resources/content-releases_it.properties
+++ b/src/main/resources/resources/content-releases_it.properties
@@ -1,4 +1,4 @@
 #/src/main/resources/resources/content-releases_it.properties
 #Wed Aug 25 12:29:39 CEST 2021
-jnt_release.name=name
-jnt_release=release
+releasent_release.name=name
+releasent_release=release

--- a/src/main/resources/resources/content-releases_pt.properties
+++ b/src/main/resources/resources/content-releases_pt.properties
@@ -1,4 +1,4 @@
 #/src/main/resources/resources/content-releases_pt.properties
 #Wed Aug 25 12:29:39 CEST 2021
-jnt_release.name=name
-jnt_release=release
+releasent_release.name=name
+releasent_release=release


### PR DESCRIPTION
## JIRA

https://support.jahia.com/browse/JAHIACOM-971

## Description

There is a conflict with the installed module on the academy platform dx-download-release-table that provide a jnt:release component that has not the "name" property and your new module.

This pull request propose to change the prefix jnt to releasent and jmix to releasemix to prevent any issue.
Not that this will make a break with the actual release.
Also, nodes under /sites/XXX/releases-manager should be recreated from scratch...

## Checklist

To test this PR, remove the existing nodes /sites/XXX/releases-manager
Disable and remove the actual 1.0.0 version
Deploy the new version.

