### PR TITLE
fix: improve DataTable implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "@jahia/data-helper": "^1.0.0",
         "@jahia/design-system-kit": "1.1.8",
         "@jahia/icons": "1.1.1",
-        "@jahia/moonstone": "^2.19.0",
+        "@jahia/moonstone": "^2.20.2",
         "@jahia/react-material": "3.0.2",
         "@jahia/ui-extender": "^1.0.0",
         "@material-ui/core": "^3.9.3",

--- a/src/javascript/ContentReleaseManager/Releases.gql-queries.js
+++ b/src/javascript/ContentReleaseManager/Releases.gql-queries.js
@@ -1,14 +1,16 @@
 import {gql} from 'apollo-boost';
-// Import {PredefinedFragments} from '@jahia/data-helper';
+import {PredefinedFragments} from '@jahia/data-helper';
 
 export const GET_RELEASES = gql`
     query getReleaseFolder($workspace: Workspace!, $path: String!,$language: String!) {
         response: jcr(workspace: $workspace) {
             releases: nodeByPath(path: $path) {
                 id: uuid
+                ...NodeCacheRequiredFields
                 children{
                     nodes {
                         id: uuid
+                        ...NodeCacheRequiredFields
                         path
                         type: primaryNodeType{
                             value:name
@@ -20,6 +22,7 @@ export const GET_RELEASES = gql`
                             nodes{
                                 node{
                                     id: uuid
+                                    ...NodeCacheRequiredFields
                                     path
                                     type: primaryNodeType{
                                         value:name
@@ -28,6 +31,7 @@ export const GET_RELEASES = gql`
                                     releases: property(name:"releases"){
                                         release : refNodes{
                                             id:uuid
+                                            ...NodeCacheRequiredFields
                                         }
                                     }
                                 }
@@ -38,7 +42,6 @@ export const GET_RELEASES = gql`
             }
         }
     }
+    ${PredefinedFragments.nodeCacheRequiredFields.gql}
 `;
-//    ${PredefinedFragments.nodeCacheRequiredFields.gql}
 // ${propsFragment}
-

--- a/src/javascript/ContentReleaseManager/components/Content/Content.jsx
+++ b/src/javascript/ContentReleaseManager/components/Content/Content.jsx
@@ -2,34 +2,10 @@ import React from 'react';
 import {StoreContext} from '../../contexts';
 import Table from './Table';
 import Help from './Help';
-import classnames from 'clsx';
-import {withStyles} from '@material-ui/core';
+import clsx from 'clsx';
+import {LayoutContent, Paper} from '@jahia/moonstone';
+import styles from './content.module.scss';
 import PropTypes from 'prop-types';
-
-const styles = () => ({
-    root: {
-        flex: '1 1 0',
-        width: '100%',
-        minHeight: 0,
-        padding: 'var(--spacing-medium)'
-    },
-    main: {
-        flex: '1 1 0%',
-        width: '100%',
-        display: 'flex',
-        position: 'relative',
-        overflow: 'hidden',
-        minHeight: 0,
-        flexDirection: 'row',
-        backgroundColor: '#ffffff'
-    },
-    container: {
-        flex: '1 2 0%',
-        order: 2,
-        display: 'flex',
-        minWidth: 0
-    }
-});
 
 const ContentCmp = ({classes}) => {
     const {state} = React.useContext(StoreContext);
@@ -46,23 +22,17 @@ const ContentCmp = ({classes}) => {
     };
 
     return (
-        <div className={classnames(
-            classes.root,
-            'flexCol'
-        )}
-        >
-            <div className={classes.main}>
-                <div className={classes.container}>
-                    {getDisplay()}
-                </div>
-            </div>
-        </div>
+        <LayoutContent className={clsx(classes)}>
+            <Paper hasPadding={false} className={clsx('flexCol_nowrap flexFluid', styles.paper)}>
+                {getDisplay()}
+            </Paper>
+        </LayoutContent>
     );
 };
 
 ContentCmp.displayName = 'Content';
 ContentCmp.propTypes = {
-    classes: PropTypes.object.isRequired
+    classes: PropTypes.object
 };
 
-export default withStyles(styles)(ContentCmp);
+export default ContentCmp;

--- a/src/javascript/ContentReleaseManager/components/Content/Table/Table.jsx
+++ b/src/javascript/ContentReleaseManager/components/Content/Table/Table.jsx
@@ -1,26 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {DataTable} from '@jahia/moonstone';
-import {TableCellActions, stringColumn} from '@jahia/moonstone/DataTable';
+import {Button, DataTable, Search} from '@jahia/moonstone';
+import {TableCellActions, TableRow, stringColumn, numberColumn} from '@jahia/moonstone/DataTable';
 import {useTranslation} from 'react-i18next';
-import {withStyles} from '@material-ui/core';
+import clsx from 'clsx';
+import styles from './table.module.scss';
 import {StoreContext} from '../../../contexts';
 import MenuAction from './Cells/MenuAction';
 
-const columnsWidth = {
-    actions: '120px',
-    items: '200px'
+const handleClick = release => {
+    const {urlbase, siteKey, lang} = window.contextJsParameters;
+    const searchType = 'releasemix:releaseItem';
+    const query = `params=(searchPath:/sites/${siteKey},sql2SearchFrom:'${searchType}',sql2SearchWhere:'releases+=!'${release.id}!'')`;
+    const url = `${urlbase}/jcontent/${siteKey}/${lang}/sql2Search/sites/${siteKey}/home?${query}`;
+    window.open(url, '_blank');
 };
-
-const styles = () => ({
-    subContainer: {
-        flex: '1 1 auto',
-        width: '100%',
-        display: 'flex',
-        minWidth: 0,
-        flexDirection: 'column'
-    }
-});
 
 const TableCmp = props => {
     const {classes} = props;
@@ -37,36 +31,45 @@ const TableCmp = props => {
         {
             key: 'items',
             label: t('label.layout.content.table.header.items'),
+            ...numberColumn(row => row.items?.length || 0),
             isSortable: true,
-            width: columnsWidth.items,
-            render: value => value.length
-        },
-        {
-            key: 'actions',
-            label: t('label.layout.content.table.header.actions'),
-            isSortable: false,
-            width: columnsWidth.actions,
-            render: (value, row) => (
-                <TableCellActions actions={<MenuAction release={row}/>}/>
-            )
+            align: 'right'
         }
     ], [t]);
 
     return (
-        <div className={classes.subContainer}>
-            <DataTable
-                enableSorting
-                enablePagination
-                data={releases}
-                columns={columns}
-                primaryKey="id"
-                defaultSortBy="name"
-                defaultSortDirection="descending"
-                defaultCurrentPage={1}
-                defaultItemsPerPage={25}
-                rowProps={{'data-cm-role': 'table-content-list-row'}}
-            />
-        </div>
+        <DataTable
+            enableSorting
+            enablePagination
+            className={clsx('flexFluid', styles.table, classes)}
+            data={releases}
+            columns={columns}
+            primaryKey="id"
+            defaultSortBy="name"
+            defaultItemsPerPage={25}
+            renderRow={({id, data, render}) => (
+                <TableRow
+                    key={id}
+                    data-cm-role="table-content-list-row"
+                    className={clsx(data.items?.length === 0 && styles.disabled)}
+                >
+                    {render({
+                        after: (
+                            <TableCellActions
+                                actions={
+                                    <>
+                                        {data.items?.length > 0 && (
+                                            <Button variant="ghost" icon={<Search/>} onClick={() => handleClick(data)}/>
+                                        )}
+                                        <MenuAction release={data}/>
+                                    </>
+                                }
+                            />
+                        )
+                    })}
+                </TableRow>
+            )}
+        />
     );
 };
 
@@ -75,4 +78,4 @@ TableCmp.propTypes = {
 };
 
 TableCmp.displayName = 'Content';
-export default withStyles(styles)(TableCmp);
+export default TableCmp;

--- a/src/javascript/ContentReleaseManager/components/Content/Table/table.module.scss
+++ b/src/javascript/ContentReleaseManager/components/Content/Table/table.module.scss
@@ -1,0 +1,7 @@
+.table {
+    overflow: auto;
+}
+
+.disabled {
+    color: var(--moon-color-gray);
+}

--- a/src/javascript/ContentReleaseManager/components/Content/content.module.scss
+++ b/src/javascript/ContentReleaseManager/components/Content/content.module.scss
@@ -1,0 +1,3 @@
+.paper {
+    overflow: hidden;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1111,7 +1111,7 @@
   dependencies:
     "@floating-ui/dom" "^1.7.6"
 
-"@floating-ui/react@^0.27.16":
+"@floating-ui/react@^0.27.19":
   version "0.27.19"
   resolved "https://registry.yarnpkg.com/@floating-ui/react/-/react-0.27.19.tgz#d8d5d895b7cb97dac370bfbf55f3e630878fdf1f"
   integrity sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==
@@ -1202,12 +1202,12 @@
     mdi-material-ui "^5.10.0"
     recompose "^0.30.0"
 
-"@jahia/moonstone@^2.19.0":
-  version "2.19.0"
-  resolved "https://npm.jahia.com/@jahia/moonstone/-/moonstone-2.19.0.tgz#fee008dd7fb01241998c73bf828e6cf933a18d99"
-  integrity sha512-iAGCK8gJzhJ9sYRkyhT825LHkJaGPc2XPpmzRm/eupva1k/N5M1CGKtwI5bb86e72ZZ9CyJ3+RbBbkkjMbNgYA==
+"@jahia/moonstone@^2.20.2":
+  version "2.20.2"
+  resolved "https://npm.jahia.com/@jahia/moonstone/-/moonstone-2.20.2.tgz#06892ad6b246cfb48bd01c433d3ccacd7ee07809"
+  integrity sha512-dCo+bJk4saDdBavdesGTzpLCdEZ351NQckatch3Jq5ofSZ+KQb3z1+H/1K561Zx9zIZXHqEwUoMoVkG7nDP8bg==
   dependencies:
-    "@floating-ui/react" "^0.27.16"
+    "@floating-ui/react" "^0.27.19"
     "@tanstack/react-table" "^8.21.3"
     clsx "^2.1.1"
     re-resizable "^6.11.2"
@@ -1460,6 +1460,9 @@
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-3.0.2.tgz#d67a6dd1ec8312d3a88ec97944a63daeef24fe10"
   integrity sha512-QY/3gJnObZQ3O/e6WjH+0ah2M3MOgLOzCy8HTUoUx9B6dDrS18vP7Ycw3qrDEKlB6q1KNxy6CZHm5FCauWGy2g==
+  dependencies:
+    "@babel/runtime" "^7.2.0"
+    recompose "0.28.0 - 0.30.0"
 
 "@material-ui/system@^3.0.0-alpha.0":
   version "3.0.0-alpha.2"
@@ -5957,7 +5960,7 @@ parse-json@^5.0.0:
 parse-unit@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parse-unit/-/parse-unit-1.0.1.tgz#7e1bb6d5bef3874c28e392526a2541170291eecf"
-  integrity sha1-fhu21b7zh0wo45JSaiVBFwKR7s8=
+  integrity sha512-hrqldJHokR3Qj88EIlV/kAyAi/G5R2+R56TBANxNMy0uPlYcttx0jnMW6Yx5KsKPSbC3KddM/7qQm3+0wEXKxg==
 
 parse5-htmlparser2-tree-adapter@^6.0.1:
   version "6.0.1"


### PR DESCRIPTION
### Description
- Update moonstone to 2.20.2. **Do we need to update a jahia-depends ?**
- Uncomment `import {PredefinedFragments} from '@jahia/data-helper';` to prevent `console.warn` on page load.
- Update the moonstone DataTable implementation to align with [version 2.20.2](https://github.com/Jahia/moonstone/releases/tag/%40jahia%2Fmoonstone%402.20.2) changes.
- Improve the DataTable implementation to follow best practices (don't set column actions in the column object).
- Add an action to each row with usages to retrieve the list of content items part of the release.
- Use moonstone components to manage page layout, to allow scrolling to the table when there are a lot of entries.
- Use a SCSS module for styles to avoid using `withStyles` (it's still used in other parts).


### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
